### PR TITLE
feat: add SecretKind annotation used by ConfigurationEvaluatorProcessor

### DIFF
--- a/src/main/java/io/gravitee/secrets/api/annotation/Secret.java
+++ b/src/main/java/io/gravitee/secrets/api/annotation/Secret.java
@@ -16,7 +16,6 @@
 package io.gravitee.secrets.api.annotation;
 
 import io.gravitee.secrets.api.el.FieldKind;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/src/main/java/io/gravitee/secrets/api/annotation/Secret.java
+++ b/src/main/java/io/gravitee/secrets/api/annotation/Secret.java
@@ -16,6 +16,7 @@
 package io.gravitee.secrets.api.annotation;
 
 import io.gravitee.secrets.api.el.FieldKind;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -31,5 +32,5 @@ public @interface Secret {
     /**
      * The secret FieldKind of the field annotated
      */
-    FieldKind value();
+    FieldKind value() default FieldKind.GENERIC;
 }

--- a/src/main/java/io/gravitee/secrets/api/annotation/Secret.java
+++ b/src/main/java/io/gravitee/secrets/api/annotation/Secret.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.SOURCE)
-public @interface SecretKind {
+public @interface Secret {
     /**
      * The secret FieldKind of the field annotated
      */

--- a/src/main/java/io/gravitee/secrets/api/annotation/SecretKind.java
+++ b/src/main/java/io/gravitee/secrets/api/annotation/SecretKind.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.secrets.api.annotation;
+
+import io.gravitee.secrets.api.el.FieldKind;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.SOURCE)
+public @interface SecretKind {
+    /**
+     * The secret FieldKind of the field annotated
+     */
+    FieldKind value();
+}

--- a/src/main/java/io/gravitee/secrets/api/el/EvaluatedSecretsMethods.java
+++ b/src/main/java/io/gravitee/secrets/api/el/EvaluatedSecretsMethods.java
@@ -16,6 +16,8 @@
 package io.gravitee.secrets.api.el;
 
 import io.gravitee.secrets.api.spec.SecretSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Define methods that are called as an EL to resolve secrets.
@@ -23,6 +25,37 @@ import io.gravitee.secrets.api.spec.SecretSpec;
  * @author GraviteeSource Team
  */
 public interface EvaluatedSecretsMethods {
+    Logger DEFAULT_METHODS_LOGGER = LoggerFactory.getLogger(EvaluatedSecretsMethods.class);
+    String SECRETS_FEATURE_DISABLED = "[secrets feature disabled]";
+    String DISABLED_ERROR_MESSAGE =
+        "gravitee-en-secrets feature is required to be in you license to use EL {#secret.get(...)}. " +
+        "Check the plugin 'service-secrets' is part of your Gravitee distribution." +
+        "'" +
+        SECRETS_FEATURE_DISABLED +
+        "' has been return instead";
+
+    /**
+     * This is called when the user entered a secret ref that is not processed
+     * because the plugin is absent or the feature missing in the license
+     * @param nameOrUri user configured name or uri
+     * @param key user configured key
+     * @return a string signaling that the feature is disabled
+     */
+    default String get(String nameOrUri, String key) {
+        return get(nameOrUri);
+    }
+
+    /**
+     *This is called when the user entered a secret ref that is not processed
+     * because the plugin is absent or the feature missing in the license
+     * @param nameOrUri user configured name or uri
+     * @return a string signaling that the feature is disabled
+     */
+    default String get(String nameOrUri) {
+        DEFAULT_METHODS_LOGGER.error(DISABLED_ERROR_MESSAGE);
+        return SECRETS_FEATURE_DISABLED;
+    }
+
     /**
      * Pulls an already resolved secret from the cache only if has been is granted to be used in the context it was discovered into.
      * The discovery context id used a token to check the secret was granted.


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7509
## Description

Add new annotation SecretKind that will be used by the ConfigurationEvaluatorProcessor to automatically add support on String field in plugin configuration and set the FieldKind of the secret.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-feat-secret-kind-annotation-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/secret/gravitee-secret-api/1.0.0-feat-secret-kind-annotation-SNAPSHOT/gravitee-secret-api-1.0.0-feat-secret-kind-annotation-SNAPSHOT.zip)
  <!-- Version placeholder end -->
