### PR TITLE
fix: change Secret annotation retention to RUNTIME

### DIFF
--- a/src/main/java/io/gravitee/secrets/api/annotation/Secret.java
+++ b/src/main/java/io/gravitee/secrets/api/annotation/Secret.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  * @author GraviteeSource Team
  */
 @Target(ElementType.FIELD)
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.RUNTIME)
 public @interface Secret {
     /**
      * The secret FieldKind of the field annotated


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7509

## Description

Since the annotation can be used in external dependencies, we need to set the retention to RUNTIME in order for the annotation processor to see them while parsing already compiled classes.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-fix-secret-annotation-retention-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/secret/gravitee-secret-api/1.0.0-fix-secret-annotation-retention-SNAPSHOT/gravitee-secret-api-1.0.0-fix-secret-annotation-retention-SNAPSHOT.zip)
  <!-- Version placeholder end -->
