### PR TITLE
fix: remove unused gravitee-node dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <gravitee-common.version>4.6.0</gravitee-common.version>
         <!-- Third party -->
         <awaitability.version>4.2.2</awaitability.version>
+        <guava.version>32.0.1-jre</guava.version>
         <!-- Plugin -->
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
         <maven-plugin-gpg.version>3.2.6</maven-plugin-gpg.version>
@@ -59,13 +60,6 @@
     </dependencyManagement>
 
     <dependencies>
-        <!-- temporary -->
-        <dependency>
-            <groupId>io.gravitee.node</groupId>
-            <artifactId>gravitee-node-api</artifactId>
-            <version>7.0.0-alpha.10</version>
-            <scope>provided</scope>
-        </dependency>
         <!-- gravitee -->
         <dependency>
             <groupId>io.gravitee.common</groupId>
@@ -74,6 +68,17 @@
             <scope>provided</scope>
         </dependency>
         <!-- third party -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.reactivex.rxjava3</groupId>
+            <artifactId>rxjava</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>


### PR DESCRIPTION
## Description

Remove unused gravitee-node dependency to prevent circular dependency with gravitee-node

## Additional context
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-remove-gravitee-node-dependency-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/secret/gravitee-secret-api/1.0.0-remove-gravitee-node-dependency-SNAPSHOT/gravitee-secret-api-1.0.0-remove-gravitee-node-dependency-SNAPSHOT.zip)
  <!-- Version placeholder end -->
