### PR TITLE
chore: fix renovate config to use the right preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,3 @@
 {
-    "extends": ["github>gravitee-io/renovate-config:policy"]
+    "extends": ["github>gravitee-io/renovate-config:lib"]
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-300

## Description

Fix the renovate preset to use the right one.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/secret/gravitee-secret-api/1.0.0/gravitee-secret-api-1.0.0.zip)
  <!-- Version placeholder end -->
