### PR TITLE
merge alpha branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# [2.0.0-alpha.1](https://github.com/gravitee-io/gravitee-secret-api/compare/1.0.0...2.0.0-alpha.1) (2025-08-13)
+
+
+### Features
+
+* add new VALUE_CHANGED event ([c30b7c6](https://github.com/gravitee-io/gravitee-secret-api/commit/c30b7c6b18b56fa61906d12f4b1a709db14fa7ca))
+* add reloadOnChange & renewable to SecretSpec ([276cca1](https://github.com/gravitee-io/gravitee-secret-api/commit/276cca1ae24c0c1d66beead2aac51ed7352ba208))
+
+
+### BREAKING CHANGES
+
+* - Add 2 options to SecretSpec `publishEventOnValueChanged` & `renewable`
+- `formatUriAndKeyAndParams` should be used instead of `formatUriAndKey`
+- `uriAndKeyAndParams` should be used instead of `uriAndKey`
+
 # 1.0.0 (2024-12-30)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.secret</groupId>
     <artifactId>gravitee-secret-api</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0-alpha.1</version>
     <name>Gravitee.io - Secret API</name>
 
     <properties>

--- a/src/main/java/io/gravitee/secrets/api/event/SecretDiscoveryEventType.java
+++ b/src/main/java/io/gravitee/secrets/api/event/SecretDiscoveryEventType.java
@@ -31,4 +31,9 @@ public enum SecretDiscoveryEventType {
      * definition to perform clean-up and evictions
      */
     REVOKE,
+    /**
+     * Event type emitted when a secret value has changed
+     * and needs to be updated in the definition
+     */
+    VALUE_CHANGED,
 }

--- a/src/main/java/io/gravitee/secrets/api/spec/SecretSpec.java
+++ b/src/main/java/io/gravitee/secrets/api/spec/SecretSpec.java
@@ -18,6 +18,7 @@ package io.gravitee.secrets.api.spec;
 import io.gravitee.common.utils.IdGenerator;
 import io.gravitee.secrets.api.core.SecretURL;
 import io.gravitee.secrets.api.el.FieldKind;
+import io.gravitee.secrets.api.event.SecretDiscoveryEventType;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -43,6 +44,8 @@ import org.springframework.util.StringUtils;
  * @param onErrorStrategy
  * @param acls            access control list: where in definitions secrets are allowed to be resolved
  * @param envId           mandatory environment ID in which this definition applies
+ * @param publishEventOnValueChanged  if true, the secret will trigger a {@link SecretDiscoveryEventType#VALUE_CHANGED} event of the definition when it's value changes.
+ * @param renewable       if true, the secret can be renewed by `renewal.enabled` configuration
  * @author Benoit BORDIGONI (benoit.bordigoni at graviteesource.com)
  * @author GraviteeSource Team
  * @see Resolution
@@ -58,7 +61,9 @@ public record SecretSpec(
     Resolution resolution,
     OnErrorStrategy onErrorStrategy,
     ACLs acls,
-    String envId
+    String envId,
+    boolean publishEventOnValueChanged,
+    boolean renewable
 ) {
     public SecretSpec {
         boolean ok = isGenerated ^ StringUtils.hasText(id);
@@ -87,11 +92,11 @@ public record SecretSpec(
     }
 
     /**
-     * Return uri and key concatenated as specified in {@link SecretSpec#formatUriAndKey(String, String)}
+     * Return uri and key concatenated as specified in {@link SecretSpec#formatUriAndKeyAndParams(String, String, boolean, boolean)}
      * @return a string concat of uri and key
      */
-    public String uriAndKey() {
-        return formatUriAndKey(uri, key);
+    public String uriAndKeyAndParams() {
+        return formatUriAndKeyAndParams(uri, key, renewable, publishEventOnValueChanged);
     }
 
     /**
@@ -99,7 +104,7 @@ public record SecretSpec(
      * @return the spec as a SecretURL
      */
     public SecretURL toSecretURL() {
-        return SecretURL.from(uriAndKey(), true);
+        return SecretURL.from(uriAndKeyAndParams(), true);
     }
 
     /**
@@ -154,11 +159,21 @@ public record SecretSpec(
     /**
      * @return main uri and optionally key concat with {@link SecretURL#URI_KEY_SEPARATOR}
      */
-    public static String formatUriAndKey(String uri, String key) {
-        if (key == null) {
-            return uri;
+    public static String formatUriAndKeyAndParams(String uri, String key, boolean renewable, boolean publishEventOnValueChanged) {
+        String urikey = uri;
+        StringBuilder params = new StringBuilder();
+        if (renewable) {
+            params.append("?");
+            params.append("renewable=true");
         }
-        return uri.concat(SecretURL.URI_KEY_SEPARATOR).concat(key);
+        if (publishEventOnValueChanged) {
+            params.append(params.isEmpty() ? "?" : "&");
+            params.append("reloadOnChange=true");
+        }
+        if (key != null) {
+            urikey = urikey.concat(SecretURL.URI_KEY_SEPARATOR).concat(key);
+        }
+        return urikey.concat(params.toString());
     }
 
     /*


### PR DESCRIPTION
## Description

add new VALUE_CHANGED event
add reloadOnChange & renewable to SecretSpec

BREAKING CHANGE:
- Add 2 options to SecretSpec `publishEventOnValueChanged` & `renewable`
- `formatUriAndKeyAndParams` should be used instead of `formatUriAndKey`
- `uriAndKeyAndParams` should be used instead of `uriAndKey`
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-merge-alpha-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/secret/gravitee-secret-api/2.0.0-merge-alpha-SNAPSHOT/gravitee-secret-api-2.0.0-merge-alpha-SNAPSHOT.zip)
  <!-- Version placeholder end -->
